### PR TITLE
Add the "putOnAHat" command and activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:extension.helloWorld"
+		"onCommand:twoHats.putOnAHat"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
 		"commands": [
 			{
-				"command": "extension.helloWorld",
-				"title": "Hello World"
+				"command": "twoHats.putOnAHat",
+				"title": "Two Hats: Put on a hat"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,27 +1,37 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
+let hat: vscode.StatusBarItem;
+
+const hatOptions = [
+	{
+		label: 'Adding functionality',
+	},
+	{
+		label: 'Refactoring',
+	}
+];
+
 export function activate(context: vscode.ExtensionContext) {
+	hat = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -100);
+	context.subscriptions.push(hat);
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-		console.log('Congratulations, your extension "two-hats" is now active!');
-
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('extension.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello VS Code');
+	const putOnAHat = vscode.commands.registerCommand('twoHats.putOnAHat', () => {
+		pickHat(hatOptions);
+		hat.show();
 	});
-
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(putOnAHat);
 }
 
-// this method is called when your extension is deactivated
+async function pickHat(hats: vscode.QuickPickItem[]) {
+	const chosenHat = await vscode.window.showQuickPick(hats, {
+		placeHolder: 'Pick a hat...',
+	});
+
+	if (!chosenHat) {
+		return;
+	}
+
+	hat.text = chosenHat.label;
+}
+
 export function deactivate() {}


### PR DESCRIPTION
The purpose of this extension is to encourage thoughtful, intentional,
disciplined programming. Fitting this theme, an explicit activation
event insists that the user take the first step -- deciding to "put on a
hat".